### PR TITLE
Fix #3: Remove hard-coded extension ID

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -12,18 +12,15 @@ import flask
 import flask_cors
 
 
-_EXTENSION_ID = 'biiglkpcdjpendjobkhgoeflaejipmfg'
-
-
 app = flask.Flask(__name__)
 cors = flask_cors.CORS(app, resources={
     r'/match': {
-        'origins': [f'chrome-extension://{_EXTENSION_ID}'],
+        'origins': ['chrome-extension://*'],
         'methods': ['POST'],
         'allow_headers': ['Content-Type']
     },
     r'/proxy-to-pixiv': {
-        'origins': [f'chrome-extension://{_EXTENSION_ID}'],
+        'origins': ['chrome-extension://*'],
         'methods': ['POST'],
         'allow_headers': ['Content-Type']
     }

--- a/src/common.js
+++ b/src/common.js
@@ -51,11 +51,9 @@ export function getLeftMostPostUrlInInnerHtml(element) {
     return null;
 }
 
-const EXTENSION_ID = 'biiglkpcdjpendjobkhgoeflaejipmfg';
-
-export function sendMessageToExtension(message) {
+export function sendMessageToExtension(extensionId, message) {
     const promise = new Promise((resolve, reject) => {
-        chrome.runtime.sendMessage(EXTENSION_ID, message, result => {
+        chrome.runtime.sendMessage(extensionId, message, result => {
             if (result === undefined) {
                 const lastError = JSON.stringify(chrome.runtime.lastError);
                 console.error(lastError);

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import { createTab, executeScript } from "./background/common";
 
 (async () => {
     const postUrls = await (async () => {
-        const result = await sendMessageToExtension({
+        const result = await sendMessageToExtension(chrome.runtime.id, {
             type: 'loadPostUrlToImages'
         });
         if (result.errorMessage !== null) {

--- a/src/injection.js
+++ b/src/injection.js
@@ -1,11 +1,14 @@
-// In order to avoid name conflicts, all global variables used in this injected
-// script are defined as a property of the object `window.nonaltReblog`.
 if ('nonaltReblog' in window === false) {
     // The presence of `window.nonaltReblog` determines whether this script has
     // been already injected into this page or not.
     window.nonaltReblog = {};
 }
+
+// When this script is injected to `https://www.tumblr.com/dashboard`, the tab
+// ID for the page is assigned to the following property.
 nonaltReblog.tabId = null;
+
+// Likewise, the extension ID is assigned to the following property.
 nonaltReblog.extensionId = null;
 
 nonaltReblog.activeElement = null;
@@ -120,7 +123,7 @@ async function initiatePreflight() {
             const message = MESSAGES[0];
             MESSAGES.shift();
             message.imageUrls = [...IMAGE_URLS];
-            const result = await sendMessageToExtension(message);
+            const result = await sendMessageToExtension(nonaltReblog.extensionId, message);
             if ('errorMessage' in result !== true) {
                 throw Error(`An unexpected message response: ${JSON.stringify(result)}`);
             }
@@ -226,7 +229,7 @@ async function initiatePreflight() {
                 const message = MESSAGES[0];
                 MESSAGES.shift();
                 message.imageUrls = [...IMAGE_URLS];
-                preflightPromise = sendMessageToExtension(message);
+                preflightPromise = sendMessageToExtension(nonaltReblog.extensionId, message);
             }
 
             if (Date.now() > sleepDeadline) {
@@ -409,7 +412,7 @@ document.addEventListener('keydown', async event => {
         return;
     }
 
-    sendMessageToExtension({
+    sendMessageToExtension(nonaltReblog.extensionId, {
         type: 'dequeueForReblogging',
         tabId: nonaltReblog.tabId
     });


### PR DESCRIPTION
- Add the parameter `extensionId` to the function `sendMessageToExtension`.
- Let the calls to `sendMessageToExtension` follow the above change.
- Let the API server accept any extension ID as the CORS origin.